### PR TITLE
fix: Don't send empty X-Amz-Security-Token header field

### DIFF
--- a/pure_websocket_subscriber.go
+++ b/pure_websocket_subscriber.go
@@ -181,15 +181,21 @@ func signRequest(signer *v4.Signer, url, region string, data []byte) (map[string
 		return nil, err
 	}
 
-	return map[string]string{
-		"accept":               req.Header.Get("accept"),
-		"content-encoding":     req.Header.Get("content-encoding"),
-		"content-type":         req.Header.Get("content-type"),
-		"host":                 req.Host,
-		"x-amz-date":           req.Header.Get("x-amz-date"),
-		"X-Amz-Security-Token": req.Header.Get("X-Amz-Security-Token"),
-		"Authorization":        req.Header.Get("Authorization"),
-	}, nil
+	headers := map[string]string{
+		"accept":           req.Header.Get("accept"),
+		"content-encoding": req.Header.Get("content-encoding"),
+		"content-type":     req.Header.Get("content-type"),
+		"host":             req.Host,
+		"x-amz-date":       req.Header.Get("x-amz-date"),
+		"Authorization":    req.Header.Get("Authorization"),
+	}
+
+	token := req.Header.Get("X-Amz-Security-Token")
+	if token != "" {
+		headers["X-Amz-Security-Token"] = token
+	}
+
+	return headers, nil
 }
 
 // Stop ends the subscription.


### PR DESCRIPTION
AWS AppSync closes the websocket connection with the `1006` code if the X-Amz-Security-Token header is empty.

Closes https://github.com/sony/appsync-client-go/issues/10

_Please note that I don't have any experience in Go. So there is probably a better and cleaner way of handling this. I'm happy to learn about it and update this PR accordingly ;-)_
