### PR TITLE
Feature/stop using default http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,7 +60,7 @@ func (c *Client) signRequest(request graphql.PostRequest) (http.Header, error) {
 	return req.Header, nil
 }
 
-//Post is a synchronous AppSync GraphQL POST request.
+// Post is a synchronous AppSync GraphQL POST request.
 func (c *Client) Post(request graphql.PostRequest) (*graphql.Response, error) {
 	defer c.sleepIfNeeded(request)
 	header := http.Header{}
@@ -81,7 +81,7 @@ func (c *Client) Post(request graphql.PostRequest) (*graphql.Response, error) {
 	return c.graphQLAPI.Post(header, request)
 }
 
-//PostAsync is an asynchronous AppSync GraphQL POST request.
+// PostAsync is an asynchronous AppSync GraphQL POST request.
 func (c *Client) PostAsync(request graphql.PostRequest, callback func(*graphql.Response, error)) (context.CancelFunc, error) {
 	header := http.Header{}
 	if request.IsSubscription() && len(c.subscriberID) > 0 {

--- a/graphql/client.go
+++ b/graphql/client.go
@@ -48,7 +48,7 @@ func NewClient(endpoint string, opts ...ClientOption) *Client {
 	return c
 }
 
-//Post is a synchronous GraphQL POST request.
+// Post is a synchronous GraphQL POST request.
 func (c *Client) Post(header http.Header, request PostRequest) (*Response, error) {
 	type ret struct {
 		response *Response
@@ -62,7 +62,7 @@ func (c *Client) Post(header http.Header, request PostRequest) (*Response, error
 	return r.response, r.err
 }
 
-//PostAsync is an asynchronous GraphQL POST request.
+// PostAsync is an asynchronous GraphQL POST request.
 func (c *Client) PostAsync(header http.Header, request PostRequest, callback func(*Response, error)) (context.CancelFunc, error) {
 	jsonBytes, err := json.Marshal(request)
 	if err != nil {

--- a/graphql/option.go
+++ b/graphql/option.go
@@ -10,21 +10,21 @@ import (
 // ClientOption represents options for a generic GraphQL client.
 type ClientOption func(*Client)
 
-//WithAPIKey returns a ClientOption configured with the given API key
+// WithAPIKey returns a ClientOption configured with the given API key
 func WithAPIKey(apiKey string) ClientOption {
 	return func(c *Client) {
 		c.header.Set("X-Api-Key", apiKey)
 	}
 }
 
-//WithCredential returns a ClientOption configured with the given credential
+// WithCredential returns a ClientOption configured with the given credential
 func WithCredential(credential string) ClientOption {
 	return func(c *Client) {
 		c.header.Set("Authorization", credential)
 	}
 }
 
-//WithHTTPProxy returns a ClientOption configured with the given http proxy
+// WithHTTPProxy returns a ClientOption configured with the given http proxy
 func WithHTTPProxy(proxy string) ClientOption {
 	return func(c *Client) {
 		proxy, err := url.Parse(proxy)
@@ -38,14 +38,14 @@ func WithHTTPProxy(proxy string) ClientOption {
 	}
 }
 
-//WithTimeout returns a ClientOption configured with the given timeout
+// WithTimeout returns a ClientOption configured with the given timeout
 func WithTimeout(timeout time.Duration) ClientOption {
 	return func(c *Client) {
 		c.timeout = timeout
 	}
 }
 
-//WithMaxElapsedTime returns a ClientOption configured with the given maxElapsedTime
+// WithMaxElapsedTime returns a ClientOption configured with the given maxElapsedTime
 func WithMaxElapsedTime(maxElapsedTime time.Duration) ClientOption {
 	return func(c *Client) {
 		c.maxElapsedTime = maxElapsedTime

--- a/graphql/option.go
+++ b/graphql/option.go
@@ -32,7 +32,7 @@ func WithHTTPProxy(proxy string) ClientOption {
 			log.Println(err)
 			return
 		}
-		if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		if t, ok := c.http.Transport.(*http.Transport); ok {
 			t.Proxy = http.ProxyURL(proxy)
 		}
 	}

--- a/graphql/option_test.go
+++ b/graphql/option_test.go
@@ -53,9 +53,9 @@ func TestWithHTTPProxy(t *testing.T) {
 	client := NewClient(testEndpoint)
 	opt := WithHTTPProxy(testProxy)
 
-	pre, ok := http.DefaultTransport.(*http.Transport)
+	pre, ok := client.http.Transport.(*http.Transport)
 	if !ok {
-		t.Fatal("http.DefaultTransport is invalid")
+		t.Fatal("client.http.Transport is invalid")
 	}
 	req, err := http.NewRequest("GET", "http://localhost", nil)
 	if err != nil {
@@ -71,9 +71,9 @@ func TestWithHTTPProxy(t *testing.T) {
 
 	opt(client)
 
-	post, ok := http.DefaultTransport.(*http.Transport)
+	post, ok := client.http.Transport.(*http.Transport)
 	if !ok {
-		t.Fatal("http.DefaultTransport is invalid")
+		t.Fatal("client.http.Transport is invalid")
 	}
 	url, err = post.Proxy(req)
 	if err != nil {

--- a/pure_websocket_subscriber_option.go
+++ b/pure_websocket_subscriber_option.go
@@ -17,7 +17,7 @@ func sanitize(host string) string {
 	return host
 }
 
-//WithAPIKey returns a PureWebSocketSubscriberOption configured with the host for the AWS AppSync GraphQL endpoint and API key
+// WithAPIKey returns a PureWebSocketSubscriberOption configured with the host for the AWS AppSync GraphQL endpoint and API key
 func WithAPIKey(host, apiKey string) PureWebSocketSubscriberOption {
 	return func(p *PureWebSocketSubscriber) {
 		p.header.Set("host", sanitize(host))
@@ -25,7 +25,7 @@ func WithAPIKey(host, apiKey string) PureWebSocketSubscriberOption {
 	}
 }
 
-//WithOIDC returns a PureWebSocketSubscriberOption configured with the host for the AWS AppSync GraphQL endpoint and JWT Access Token.
+// WithOIDC returns a PureWebSocketSubscriberOption configured with the host for the AWS AppSync GraphQL endpoint and JWT Access Token.
 func WithOIDC(host, jwt string) PureWebSocketSubscriberOption {
 	return func(p *PureWebSocketSubscriber) {
 		p.header.Set("host", sanitize(host))


### PR DESCRIPTION
Synchronize the lifetime of a http.Client's connection pool with the lifetime of appsync.Client to avoid waiting for the connection timeout by re-creating the instance if the system network interface has changed.