### PR TITLE
switch the connection lost from string check to error type check.

### DIFF
--- a/pure_websocket_subscriber.go
+++ b/pure_websocket_subscriber.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -222,7 +222,7 @@ func (r *realtimeWebSocketOperation) readLoop() {
 		_, payload, err := r.ws.ReadMessage()
 		if err != nil {
 			log.Println(err)
-			if strings.Contains(err.Error(), "i/o timeout") {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				r.onConnectionLost(err)
 			}
 			return


### PR DESCRIPTION
Previously the code, is checking for an error string containing "i/o timeout" to handle connection loss. However, the error message "read: operation timed out" does not match the check.

To address this, I modified the error checking to cover more cases. Instead of looking for a specific error string, check for a timeout is using the net.Error interface and its Timeout() method. This approach is generally more reliable and less prone to breakage if the error messages change.

https://github.com/sony/appsync-client-go/issues/26#issue-2066300712