### PR TITLE
Switching from log to slog.

### DIFF
--- a/appsync_example_test.go
+++ b/appsync_example_test.go
@@ -3,7 +3,8 @@ package appsync_test
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/sony/appsync-client-go/internal/appsynctest"
@@ -22,12 +23,14 @@ func ExampleClient_Post_query() {
 		Query: query,
 	})
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("unable to post query", "error", err)
+		os.Exit(1)
 	}
 
 	data := new(string)
 	if err := response.DataAs(data); err != nil {
-		log.Fatalln(err, response)
+		slog.Error("unable to process data", "error", err, "response", response)
+		os.Exit(1)
 	}
 	fmt.Println(*data)
 
@@ -47,12 +50,14 @@ func ExampleClient_Post_mutation() {
 		Variables: &variables,
 	})
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("unable to post mutation", "error", err)
+		os.Exit(1)
 	}
 
 	data := new(string)
 	if err := response.DataAs(data); err != nil {
-		log.Fatalln(err, response)
+		slog.Error("unable to process data", "error", err, "response", response)
+		os.Exit(1)
 	}
 	fmt.Println(*data)
 
@@ -70,22 +75,27 @@ func ExampleClient_mqtt_subscription() {
 		Query: subscription,
 	})
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("unable to post subscription", "error", err)
+		os.Exit(1)
 	}
 
 	ext, err := appsync.NewExtensions(response)
 	if err != nil {
-		log.Fatalln(err)
+		slog.Error("unable to process extensions", "error", err)
+		os.Exit(1)
 	}
 
 	ch := make(chan *graphql.Response)
 	subscriber := appsync.NewSubscriber(*ext,
 		func(r *graphql.Response) { ch <- r },
-		func(err error) { log.Println(err) },
+		func(err error) {
+			slog.Warn("unable to create new subscriber", "error", err)
+		},
 	)
 
 	if err := subscriber.Start(); err != nil {
-		log.Fatalln(err)
+		slog.Error("unable to start subscriber", "error", err)
+		os.Exit(1)
 	}
 	defer subscriber.Stop()
 
@@ -96,13 +106,15 @@ func ExampleClient_mqtt_subscription() {
 		Variables: &variables,
 	})
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("unable to post mutation", "error", err)
+		os.Exit(1)
 	}
 
 	response = <-ch
 	data := new(string)
 	if err := response.DataAs(data); err != nil {
-		log.Fatalln(err, response)
+		slog.Error("unable to process data", "error", err, "response", response)
+		os.Exit(1)
 	}
 	fmt.Println(*data)
 
@@ -124,11 +136,14 @@ func ExampleClient_graphqlws_subscription() {
 			Query: subscription,
 		},
 		func(r *graphql.Response) { ch <- r },
-		func(err error) { log.Println(err) },
+		func(err error) {
+			slog.Warn("unable to create new pure websocket subscriber  ", "error", err)
+		},
 	)
 
 	if err := subscriber.Start(); err != nil {
-		log.Fatalln(err)
+		slog.Error("unable to start subscriber", "error", err)
+		os.Exit(1)
 	}
 	defer subscriber.Stop()
 
@@ -139,13 +154,15 @@ func ExampleClient_graphqlws_subscription() {
 		Variables: &variables,
 	})
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("unable to post mutation", "error", err)
+		os.Exit(1)
 	}
 
 	response := <-ch
 	data := new(string)
 	if err := response.DataAs(data); err != nil {
-		log.Fatalln(err, response)
+		slog.Error("unable to process data", "error", err, "response", response)
+		os.Exit(1)
 	}
 	fmt.Println(*data)
 

--- a/client.go
+++ b/client.go
@@ -3,7 +3,7 @@ package appsync
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -45,12 +45,12 @@ func (c *Client) setupHeaders(request graphql.PostRequest) (http.Header, error) 
 
 	jsonBytes, err := json.Marshal(request)
 	if err != nil {
-		log.Println(err)
+		slog.Error("unable to marshal request", "error", err, "request", request)
 		return nil, err
 	}
 	h, err := c.signer.signHTTP(jsonBytes)
 	if err != nil {
-		log.Println(err)
+		slog.Error("unable to sign request", "error", err, "request", request)
 		return nil, err
 	}
 	for k, vv := range h {
@@ -66,7 +66,7 @@ func (c *Client) Post(request graphql.PostRequest) (*graphql.Response, error) {
 	defer c.sleepIfNeeded(request)
 	header, err := c.setupHeaders(request)
 	if err != nil {
-		log.Println(err)
+		slog.Error("unable to setup headers", "error", err, "request", request)
 		return nil, err
 	}
 	return c.graphQLAPI.Post(header, request)
@@ -76,7 +76,7 @@ func (c *Client) Post(request graphql.PostRequest) (*graphql.Response, error) {
 func (c *Client) PostAsync(request graphql.PostRequest, callback func(*graphql.Response, error)) (context.CancelFunc, error) {
 	header, err := c.setupHeaders(request)
 	if err != nil {
-		log.Println(err)
+		slog.Error("unable to setup headers", "error", err, "request", request)
 		return nil, err
 	}
 	cb := func(g *graphql.Response, err error) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sony/appsync-client-go
 
-go 1.20
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go v1.44.245

--- a/graphql/option.go
+++ b/graphql/option.go
@@ -1,7 +1,7 @@
 package graphql
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
@@ -29,7 +29,7 @@ func WithHTTPProxy(proxy string) ClientOption {
 	return func(c *Client) {
 		proxy, err := url.Parse(proxy)
 		if err != nil {
-			log.Println(err)
+			slog.Warn("unable to parse proxy URL", "error", err)
 			return
 		}
 		if t, ok := c.http.Transport.(*http.Transport); ok {

--- a/graphql/response.go
+++ b/graphql/response.go
@@ -20,7 +20,7 @@ func (r *Response) DataAs(v interface{}) error {
 		return fmt.Errorf("data is invalid")
 	}
 	if len(m) != 1 {
-		return fmt.Errorf("the data is not exist")
+		return fmt.Errorf("the data does not exist")
 	}
 	for _, value := range m {
 		if b, err := json.Marshal(value); err == nil {

--- a/pure_websocket_subscriber.go
+++ b/pure_websocket_subscriber.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"time"
@@ -119,7 +119,7 @@ func (p *PureWebSocketSubscriber) setupHeaders(payload []byte) (map[string]strin
 
 	headers, err := p.sigv4.signWS(payload)
 	if err != nil {
-		log.Println(err)
+		slog.Error("error signing WS headers", "error", err)
 		return nil, err
 	}
 
@@ -131,36 +131,36 @@ func (p *PureWebSocketSubscriber) Start() error {
 	bpayload := []byte("{}")
 	header, err := p.setupHeaders(bpayload)
 	if err != nil {
-		log.Println(err)
+		slog.Error("error setting up headers", "error", err)
 		return err
 	}
 	bheader, err := json.Marshal(header)
 	if err != nil {
-		log.Println(err)
+		slog.Error("error marshalling headers during Start", "error", err, "header", header)
 		return err
 	}
 	if err := p.op.connect(p.realtimeEndpoint, bheader, bpayload); err != nil {
-		log.Println(err)
+		slog.ErrorContext(p.op.ctx, "error connecting to websocket", "error", err, "realtimeEndpoint", p.realtimeEndpoint, "header", bheader, "payload", bpayload)
 		return err
 	}
 
 	if err := p.op.connectionInit(); err != nil {
-		log.Println(err)
+		slog.ErrorContext(p.op.ctx, "error initializing connection", "error", err)
 		return err
 	}
 
 	brequest, err := json.Marshal(p.request)
 	if err != nil {
-		log.Println(err)
+		slog.ErrorContext(p.op.ctx, "error marshalling request", "error", err, "request", p.request)
 		return err
 	}
 	authz, err := p.setupHeaders(brequest)
 	if err != nil {
-		log.Println(err)
+		slog.ErrorContext(p.op.ctx, "error setting up headers", "error", err)
 		return err
 	}
 	if err := p.op.start(brequest, authz); err != nil {
-		log.Println(err)
+		slog.ErrorContext(p.op.ctx, "error starting subscription", "error", err)
 		return err
 	}
 
@@ -206,7 +206,7 @@ func (r *realtimeWebSocketOperation) readLoop() {
 	defer close(r.completeCh)
 
 	if err := r.ws.SetReadDeadline(time.Now().Add(defaultTimeout)); err != nil {
-		log.Println(err)
+		slog.Error("error setting read deadline", "error", err)
 		return
 	}
 	for {
@@ -221,22 +221,25 @@ func (r *realtimeWebSocketOperation) readLoop() {
 
 		_, payload, err := r.ws.ReadMessage()
 		if err != nil {
-			log.Println(err)
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				r.onConnectionLost(err)
+				slog.Warn("connection timeout")
+			} else {
+				slog.ErrorContext(r.ctx, "error reading message", "error", err)
 			}
+			r.onConnectionLost(err)
 			return
 		}
 
 		msg := new(message)
 		if err := json.Unmarshal(payload, msg); err != nil {
-			log.Println(err)
+			slog.ErrorContext(r.ctx, "error unmarshalling message", "error", err, "payload", string(payload))
 			return
 		}
 
 		handler, ok := handlers[msg.Type]
+		slog.Debug("msg", "payload", string(payload), "ok", ok)
 		if !ok {
-			log.Println("invalid message received: " + msg.Type)
+			slog.Warn("invalid message received", "msgType", msg.Type)
 			continue
 		}
 		if handler(payload) {
@@ -257,13 +260,13 @@ func (r *realtimeWebSocketOperation) connect(realtimeEndpoint string, header, pa
 	if err := backoff.Retry(func() error {
 		ws, _, err := websocket.DefaultDialer.DialContext(r.ctx, endpoint, http.Header{"sec-websocket-protocol": []string{"graphql-ws"}})
 		if err != nil {
-			log.Print(err)
+			slog.Error("error connecting to websocket", "error", err)
 			return err
 		}
 		r.ws = ws
 		return nil
 	}, backoff.WithContext(backoff.NewExponentialBackOff(), r.ctx)); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error connecting to websocket", "error", err)
 		return err
 	}
 
@@ -278,7 +281,7 @@ func (r *realtimeWebSocketOperation) connect(realtimeEndpoint string, header, pa
 func (r *realtimeWebSocketOperation) onConnected(payload []byte) bool {
 	connack := new(connectionAckMessage)
 	if err := json.Unmarshal(payload, connack); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error unmarshalling connection_ack", "error", err)
 		return true
 	}
 	r.connackCh <- *connack
@@ -292,11 +295,11 @@ func (r *realtimeWebSocketOperation) connectionInit() error {
 
 	init, err := json.Marshal(connectionInitMsg)
 	if err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error marshalling connection_init", "error", err)
 		return err
 	}
 	if err := r.ws.WriteMessage(websocket.TextMessage, init); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error writing connection_init", "error", err)
 		return err
 	}
 	connack, ok := <-r.connackCh
@@ -314,7 +317,7 @@ func (r *realtimeWebSocketOperation) onKeepAlive([]byte) bool {
 		timeout = r.connectionTimeout
 	}
 	if err := r.ws.SetReadDeadline(time.Now().Add(timeout)); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error setting read deadline", "error", err)
 		return true
 	}
 	return false
@@ -338,17 +341,19 @@ func (r *realtimeWebSocketOperation) start(request []byte, authorization map[str
 
 	b, err := json.Marshal(start)
 	if err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error marshalling start", "error", err)
 		return err
 	}
 	if err := r.ws.WriteMessage(websocket.TextMessage, b); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error writing start", "error", err)
 	}
 	startack, ok := <-r.startackCh
 	if !ok {
 		return errors.New("subscription registration failed")
 	}
+
 	r.subscriptionID = startack.ID
+	slog.Debug("subscriptionID", "id", r.subscriptionID)
 
 	return nil
 }
@@ -356,7 +361,7 @@ func (r *realtimeWebSocketOperation) start(request []byte, authorization map[str
 func (r *realtimeWebSocketOperation) onStarted(payload []byte) bool {
 	startack := new(startAckMessage)
 	if err := json.Unmarshal(payload, startack); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error unmarshalling start_ack", "error", err)
 		return true
 	}
 	r.startackCh <- *startack
@@ -366,7 +371,7 @@ func (r *realtimeWebSocketOperation) onStarted(payload []byte) bool {
 func (r *realtimeWebSocketOperation) onData(payload []byte) bool {
 	data := new(processingDataMessage)
 	if err := json.Unmarshal(payload, data); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error unmarshalling onData payload", "error", err)
 		return true
 	}
 	r.onReceive(&graphql.Response{
@@ -383,15 +388,15 @@ func (r *realtimeWebSocketOperation) stop() {
 	stop := stopMessage{message{"stop"}, r.subscriptionID}
 	b, err := json.Marshal(stop)
 	if err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error marshalling stop", "error", err)
 		return
 	}
 	if err := r.ws.WriteMessage(websocket.TextMessage, b); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error writing stop", "error", err)
 		return
 	}
 	if _, ok := <-r.completeCh; !ok {
-		log.Println("unsubscribe failed")
+		slog.Warn("subscription stop failed")
 	}
 	r.subscriptionID = ""
 }
@@ -399,7 +404,7 @@ func (r *realtimeWebSocketOperation) stop() {
 func (r *realtimeWebSocketOperation) onStopped(payload []byte) bool {
 	complete := new(completeMessage)
 	if err := json.Unmarshal(payload, complete); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error unmarshalling onStopped complete msg", "error", err, "payload", string(payload))
 		return true
 	}
 	r.completeCh <- *complete
@@ -412,7 +417,7 @@ func (r *realtimeWebSocketOperation) disconnect() {
 	}
 
 	if err := r.ws.Close(); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error closing websocket", "error", err)
 	}
 	r.connectionTimeout = 0
 	r.ws = nil
@@ -421,7 +426,7 @@ func (r *realtimeWebSocketOperation) disconnect() {
 func (r *realtimeWebSocketOperation) onError(payload []byte) bool {
 	em := new(errorMessage)
 	if err := json.Unmarshal(payload, em); err != nil {
-		log.Println(err)
+		slog.ErrorContext(r.ctx, "error unmarshalling onError payload", "error", err, "payload", string(payload))
 		return true
 	}
 	errors := make([]interface{}, len(em.Payload.Errors))

--- a/pure_websocket_subscriber.go
+++ b/pure_websocket_subscriber.go
@@ -94,6 +94,7 @@ func NewPureWebSocketSubscriber(realtimeEndpoint string, request graphql.PostReq
 	onReceive func(response *graphql.Response),
 	onConnectionLost func(err error),
 	opts ...PureWebSocketSubscriberOption) *PureWebSocketSubscriber {
+	slog.Debug("creating new pure websocket subscriber", "realtimeEndpoint", realtimeEndpoint, "request", request)
 	ctx, cancel := context.WithCancel(context.Background())
 	p := PureWebSocketSubscriber{
 		realtimeEndpoint: realtimeEndpoint,
@@ -109,7 +110,9 @@ func NewPureWebSocketSubscriber(realtimeEndpoint string, request graphql.PostReq
 }
 
 func (p *PureWebSocketSubscriber) setupHeaders(payload []byte) (map[string]string, error) {
+	slog.Debug("setting up headers", "payload", string(payload))
 	if p.sigv4 == nil {
+		slog.Debug("no sigV4")
 		headers := map[string]string{}
 		for k := range p.header {
 			headers[k] = p.header.Get(k)
@@ -117,6 +120,7 @@ func (p *PureWebSocketSubscriber) setupHeaders(payload []byte) (map[string]strin
 		return headers, nil
 	}
 
+	slog.Debug("signing ws headers", "payload", string(payload))
 	headers, err := p.sigv4.signWS(payload)
 	if err != nil {
 		slog.Error("error signing WS headers", "error", err)

--- a/sigv4.go
+++ b/sigv4.go
@@ -6,7 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -32,20 +32,20 @@ type _signer struct {
 func (s *_signer) signHTTP(payload []byte) (http.Header, error) {
 	req, err := http.NewRequest("POST", s.url, bytes.NewBuffer(payload))
 	if err != nil {
-		log.Println(err)
+		slog.Error("error creating request", "error", err)
 		return nil, err
 	}
 	switch signer := s.sdkSigner.(type) {
 	case *sdkv1_v4.Signer:
 		_, err = signer.Sign(req, bytes.NewReader(payload), "appsync", s.region, time.Now())
 		if err != nil {
-			log.Println(err)
+			slog.Error("error signing request", "error", err)
 			return nil, err
 		}
 	case *sdkv2_v4.Signer:
 		hash := sha256.Sum256(payload)
 		if err := signer.SignHTTP(context.TODO(), *s.creds, req, hex.EncodeToString(hash[:]), "appsync", s.region, time.Now()); err != nil {
-			log.Println(err)
+			slog.Error("error signing request", "error", err)
 			return nil, err
 		}
 	default:
@@ -61,7 +61,7 @@ func (s *_signer) signWS(payload []byte) (map[string]string, error) {
 	}
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
 	if err != nil {
-		log.Println(err)
+		slog.Error("error creating request", "error", err)
 		return nil, err
 	}
 
@@ -73,7 +73,7 @@ func (s *_signer) signWS(payload []byte) (map[string]string, error) {
 	case *sdkv1_v4.Signer:
 		_, err = signer.Sign(req, bytes.NewReader(payload), "appsync", s.region, time.Now())
 		if err != nil {
-			log.Println(err)
+			slog.Error("error signing request", "error", err)
 			return nil, err
 		}
 		return map[string]string{
@@ -88,7 +88,7 @@ func (s *_signer) signWS(payload []byte) (map[string]string, error) {
 	case *sdkv2_v4.Signer:
 		hash := sha256.Sum256(payload)
 		if err := signer.SignHTTP(context.TODO(), *s.creds, req, hex.EncodeToString(hash[:]), "appsync", s.region, time.Now()); err != nil {
-			log.Println(err)
+			slog.Error("error signing request", "error", err)
 			return nil, err
 		}
 

--- a/subscriber.go
+++ b/subscriber.go
@@ -30,6 +30,7 @@ const (
 
 // NewSubscriber returns a new Subscriber instance.
 func NewSubscriber(extensions Extensions, callback func(response *graphql.Response), onConnectionLost func(err error)) *Subscriber {
+	slog.Debug("creating new subscriber", "extensions", extensions)
 	if len(extensions.Subscription.MqttConnections) == 0 {
 		slog.Warn("There is no mqtt connections.", "extensions", extensions)
 		return nil
@@ -41,6 +42,7 @@ func NewSubscriber(extensions Extensions, callback func(response *graphql.Respon
 			return ""
 		}
 		for _, v := range extensions.Subscription.NewSubscriptions {
+			slog.Debug("topics", "topic", v.Topic)
 			return v.Topic
 		}
 		return ""
@@ -95,6 +97,7 @@ func (r *rwBool) store(b bool) {
 
 // Start starts a new subscription.
 func (s *Subscriber) Start() error {
+	slog.Debug("starting new subscriber", "clientID", s.clientID, "url", s.url, "topic", s.topic)
 	opts := MQTT.NewClientOptions().
 		AddBroker(s.url).
 		SetClientID(s.clientID).
@@ -159,6 +162,7 @@ func (s *Subscriber) Start() error {
 
 // Stop ends the subscription.
 func (s *Subscriber) Stop() {
+	slog.Debug("stopping subscriber", "topic", s.topic)
 	if s.mqtt == nil {
 		return
 	}


### PR DESCRIPTION
switching from the standard library log to the new slog library.

- switching from ioutils to io for deprecated call:
body, err := io.ReadAll(r.Body)

- moving r.onConnectionLost(err) from the if netErr, ok := err.(net.Error); ok && netErr.Timeout() to outside the scope. This is to catch RTS network errors when AWS AppSync unexpectedly closes the connection.