### PR TITLE
bump go version to 1.21 on rocro

### DIFF
--- a/rocro.yml
+++ b/rocro.yml
@@ -6,7 +6,7 @@ inspecode:
       - "internal/"
       - "**/*_test.go"
     runtime:
-      go: 1.20
+      go: 1.21
   cpd: default
   dependency-check:
     machine:


### PR DESCRIPTION
fix the inspecode go runtime setting.