### PR TITLE
bump Go version to 1.24 and update toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/sony/appsync-client-go
 
-go 1.23
-toolchain go1.24.1
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go v1.55.5


### PR DESCRIPTION
This pull request updates the Go module configuration in the `go.mod` file to align with the latest Go version requirements.

Updates to Go module configuration:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.23` to `1.24` and removed the `toolchain` directive specifying `go1.24.1`.